### PR TITLE
change the way of context passing in EventLoop::post

### DIFF
--- a/znet.hpp
+++ b/znet.hpp
@@ -139,17 +139,13 @@ inline bool EventLoop::initialize()
     return true;
 }
 
-inline void post_cb(void *ud, zn_State *) 
-{
-    std::unique_ptr<OnPostHandler> h
-        (reinterpret_cast<OnPostHandler*>(ud));
-    (*h)();
-}
-
 inline void EventLoop::post(OnPostHandler&& h)
 {
-    auto newh = new OnPostHandler(h);
-    zn_post(S, post_cb, newh);
+    zn_post(S, [](void *ud, zn_State *) {
+        std::unique_ptr<OnPostHandler> h
+            (reinterpret_cast<OnPostHandler*>(ud));
+        (*h)();
+    }, new OnPostHandler(std::move(h)));
 }
 
 static inline zn_Time timer_cb(void *ud, zn_Timer *timer, unsigned elapsed)


### PR DESCRIPTION
1. TcpAccept::acceptHandler是不是仅仅为了将一个handler通过this传给zn_accept？
   现在这样改会不会有问题？ 比如zn_accept会保存这个这个指针，然后在什么时候偷偷调用。。。
   accpet感觉明显不会。。。 其他的不清楚。。。
2. acceptHandler是在哪初始化的啊。。。
   if (zn_accept(accept, accept_cb, this) == ...)时this->acceptHandler是空的吧？ if里面才赋值？
3. 对比post_cb
   我觉得这样改应该不会错。从EventLoop::post的代码里就可以看出zn_post对handler是用完就忘。
   但TcpAccept::acceptHandler会给人有故意延长它生命周期的感觉。。。
