### PR TITLE
fix memory leak

### DIFF
--- a/znet_epoll.h
+++ b/znet_epoll.h
@@ -642,7 +642,7 @@ ZN_API zn_Time zn_time(void) {
 ZN_API int zn_post(zn_State *S, zn_PostHandler *cb, void *ud) {
     zn_Post *ps;
     if (S->status > ZN_STATUS_READY
-            || (ps = (zn_Post*)malloc(sizeof(zn_Post))) != NULL)
+            || (ps = (zn_Post*)malloc(sizeof(zn_Post))) == NULL)
         return 0;
     ps->handler = cb;
     ps->ud = ud;


### PR DESCRIPTION
1. 这个应该是memory leak吧？  
   虽然ZN_STATUS_READY的含义暂不清楚，但只要执行了||部分，并且!=NULL就会return。局部变量ps的值也没存放到其他地方。
   iocp,select里对应地方都是==NULL。
2. 好多代码重复的。。。  post,add,process....
3. post就是添加一次性执行的任务？  可以用超时=0的timer任务达到类似效果么？ 效率？
