### PR TITLE
Don't block in zn_run if there are still some pending results.

### DIFF
--- a/znet.h
+++ b/znet.h
@@ -559,14 +559,18 @@ ZN_API void zn_close(zn_State *S) {
 
 ZN_API int zn_run(zn_State *S, int mode) {
     int err;
+    // Never block if there are still pending results to process.
+    // This can happen e.g if we send a ton of stuff in a row, 
+    // hitting the ZN_MAX_RESULT_LOOPS limit.
+    int maybe_force_check_only = znQ_empty(&S->result_queue) ? 0 : 1;
     switch (mode) {
     case ZN_RUN_CHECK:
         return znS_poll(S, 1);
     case ZN_RUN_ONCE:
-        return znS_poll(S, 0);
+        return znS_poll(S, maybe_force_check_only);
     case ZN_RUN_LOOP:
-        while ((err = znS_poll(S, 0)) > 0)
-            ;
+        while ((err = znS_poll(S, maybe_force_check_only)) > 0)
+            maybe_force_check_only = znQ_empty(&S->result_queue) ? 0 : 1;
         return err;
     }
     return -ZN_ERROR;


### PR DESCRIPTION
If we hit the ZN_MAX_RESULT_LOOPS limit (e.g. doing a long series of small sends), then the pending results might never get processed and zn_run could get stuck forever. Below is some minimal code to reproduce. It just sends small chunks of data forever, and without this PR only 100 messages will be sent and then we may block forever in zn_run / znS_poll if no signal or recv interrupts it.

```
#define ZN_IMPLEMENTATION
#include "znet.h"
#include "assert.h"

/* 
    To reproduce on Unix:

    In one terminal, launch a netcat server:
    $ nc -lk 5555

    In another:
    $ cc flood_senc.c && ./a.out

    Without the bug fix, only 100 (ZN_MAX_RESULT_LOOPS) messages will
    be sent and then zn_run will block forever in epoll_wait.

    With the bug fix, data will be sent continuously as expected.
*/

zn_State *S;

static void send_data(zn_Tcp *tcp);

static void on_send(void *ud, zn_Tcp *tcp, unsigned err, unsigned count) {
    assert (err == ZN_OK);
    send_data (tcp);
}

static void send_data(zn_Tcp *tcp)
{
    static const char fake_data[] = "DATA";
    zn_send(tcp,
            fake_data,
            sizeof(fake_data)/sizeof(char),
            on_send,
            NULL);
}

static void on_connect(void *ud, zn_Tcp *tcp, unsigned err) {
    assert (err == ZN_OK);
    send_data (tcp);
}

int main(int argc, char **argv) {
    zn_initialize();
    S = zn_newstate();
    assert (S != NULL);

    zn_Tcp *tcp = zn_newtcp(S);
    zn_connect(tcp, "127.0.0.1", 5555, 0, on_connect, NULL);
    return zn_run(S, ZN_RUN_LOOP);
}
```