### PR TITLE
Process pending events before blocking for all polling methods, not just epoll.

### DIFF
--- a/znet.h
+++ b/znet.h
@@ -2759,6 +2759,8 @@ static int znP_poll(zn_State *S, zn_Time timeout) {
         ms.tv_nsec = (timeout % 1000) * 1000000;
         pms = &ms;
     }
+    if (znR_process(S, 0))
+        return 1;
     ret = kevent(S->kqueue, NULL, 0, S->events, ZN_MAX_EVENTS, pms);
     if (ret < 0) /* error out */
         return 0;


### PR DESCRIPTION
This is a follow up of #20 . The changes in master fixed the problem on Linux with epoll, but I hit a similar issue on macOS with kevent. Unfortunately this time I don't have a toy example to reproduce on mac, but intuitively the same fix could be necessary for all the polling method, so we never block when there are still previous events to process. This fixes the issue for me on macOS.
